### PR TITLE
feat(promptsmith): add customizable keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pi install git:github.com/ayagmar/pi-promptsmith
 
 Write a rough request in the Pi editor, then:
 
-- press `Alt+P`, or
+- press `Alt+P` by default (or your custom Promptsmith shortcut), or
 - run `/promptsmith`
 
 Promptsmith rewrites the current draft directly in the editor.
@@ -176,6 +176,8 @@ Inside the interactive settings and model pickers:
 - large model lists are paginated to stay compact
 - press `/` to open search in the compact selector
 - `PageUp` / `PageDown` switch pages in paginated selectors
+- the keyboard shortcut row lets you turn the shortcut on or off, remap it, or reset it to `Alt+P`
+- when remapping, press the new key combo directly; `Esc` cancels and `Backspace` resets to default
 
 Quick config:
 
@@ -208,6 +210,7 @@ Promptsmith saves global settings in:
 
 Important defaults:
 
+- keyboard shortcut = `Alt+P`
 - rewrite mode = `auto`
 - rewrite strength = `balanced`
 - status bar = `off`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ import type { PromptsmithSettings } from "./types.js";
 export const EXTENSION_NAME = "pi-promptsmith";
 export const EXTENSION_COMMAND = "promptsmith";
 // Avoid Pi built-ins and common extension collisions.
-export const SHORTCUT_KEY = "alt+p";
+export const DEFAULT_SHORTCUT_KEY = "alt+p";
 
 export const SETTINGS_VERSION = 1;
 export const SENTINEL_OPEN = "<promptsmith-enhanced-prompt>";
@@ -25,6 +25,7 @@ export const DEFAULT_SETTINGS: PromptsmithSettings = {
   version: SETTINGS_VERSION,
   enabled: true,
   shortcutEnabled: true,
+  shortcutKey: DEFAULT_SHORTCUT_KEY,
   targetFamilyMode: "auto",
   fallbackFamily: "gpt",
   exactModelOverrides: [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 import { complete } from "@mariozechner/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { CompleteFn } from "./enhance.js";
-import { EXTENSION_COMMAND, SHORTCUT_KEY } from "./constants.js";
+import { DEFAULT_SHORTCUT_KEY, EXTENSION_COMMAND } from "./constants.js";
 import { getPromptsmithArgumentCompletions, handlePromptsmithCommand } from "./commands.js";
+import { runEnhancementWithLoader } from "./enhance.js";
+import { formatShortcutKey, normalizeShortcutKey } from "./shortcut-key.js";
 import { PromptsmithRuntimeState } from "./state.js";
 import { handlePromptsmithShortcut } from "./shortcut.js";
-import { runEnhancementWithLoader } from "./enhance.js";
+import { PromptsmithEditor } from "./ui/promptsmith-editor.js";
 import { openSettingsUi } from "./ui/settings.js";
 import { refreshStatusLine } from "./ui/status.js";
 
@@ -18,9 +20,71 @@ export function createPromptsmithExtension(
   options?: { completeFn?: CompleteFn }
 ): void {
   const runtime = new PromptsmithRuntimeState();
+  let ownsEditorComponent = false;
+
+  const applyEditorComponent = (ctx: ExtensionContext): void => {
+    if (!ctx.hasUI) {
+      return;
+    }
+
+    const settings = runtime.getSettings();
+    const shortcutKey = normalizeShortcutKey(settings.shortcutKey) ?? DEFAULT_SHORTCUT_KEY;
+    const shouldUseCustomEditor =
+      settings.enabled && settings.shortcutEnabled && shortcutKey !== DEFAULT_SHORTCUT_KEY;
+
+    if (!shouldUseCustomEditor) {
+      if (ownsEditorComponent) {
+        ctx.ui.setEditorComponent(undefined);
+        ownsEditorComponent = false;
+      }
+      return;
+    }
+
+    ownsEditorComponent = true;
+    ctx.ui.setEditorComponent(
+      (tui, theme, keybindings) =>
+        new PromptsmithEditor(
+          tui,
+          theme,
+          keybindings,
+          () => runtime.getSettings(),
+          () => {
+            void handlePromptsmithShortcut(ctx, runtime, {
+              completeFn: options?.completeFn ?? complete,
+              exec: pi.exec.bind(pi),
+              refreshStatus,
+              runCancellableTask: runEnhancementWithLoader,
+              openSettings,
+            });
+          }
+        )
+    );
+  };
 
   const refreshStatus = (ctx: ExtensionContext): void => {
+    applyEditorComponent(ctx);
     refreshStatusLine(ctx, runtime);
+  };
+
+  const openSettings = async (ctx: ExtensionContext): Promise<void> => {
+    await openSettingsUi(ctx, runtime, { refreshStatus });
+  };
+
+  const triggerDefaultShortcut = async (ctx: ExtensionContext): Promise<void> => {
+    const settings = runtime.getSettings();
+    const shortcutKey = normalizeShortcutKey(settings.shortcutKey) ?? DEFAULT_SHORTCUT_KEY;
+    if (settings.enabled && settings.shortcutEnabled && shortcutKey !== DEFAULT_SHORTCUT_KEY) {
+      ctx.ui.notify(`Promptsmith shortcut is now ${formatShortcutKey(shortcutKey)}.`, "info");
+      return;
+    }
+
+    await handlePromptsmithShortcut(ctx, runtime, {
+      completeFn: options?.completeFn ?? complete,
+      exec: pi.exec.bind(pi),
+      refreshStatus,
+      runCancellableTask: runEnhancementWithLoader,
+      openSettings,
+    });
   };
 
   const restorePersistedSettings = (ctx: ExtensionContext): void => {
@@ -57,18 +121,10 @@ export function createPromptsmithExtension(
     },
   });
 
-  pi.registerShortcut(SHORTCUT_KEY, {
+  pi.registerShortcut(DEFAULT_SHORTCUT_KEY, {
     description: "Enhance the current editor prompt",
     handler: async (ctx) => {
-      await handlePromptsmithShortcut(ctx, runtime, {
-        completeFn: options?.completeFn ?? complete,
-        exec: pi.exec.bind(pi),
-        refreshStatus,
-        runCancellableTask: runEnhancementWithLoader,
-        openSettings: async (settingsCtx) => {
-          await openSettingsUi(settingsCtx, runtime, { refreshStatus });
-        },
-      });
+      await triggerDefaultShortcut(ctx);
     },
   });
 }

--- a/src/shortcut-key.ts
+++ b/src/shortcut-key.ts
@@ -1,0 +1,286 @@
+import { matchesKey, type KeyId } from "@mariozechner/pi-tui";
+import { DEFAULT_SHORTCUT_KEY } from "./constants.js";
+import type { PromptsmithSettings } from "./types.js";
+
+const MODIFIER_ORDER = ["ctrl", "shift", "alt"] as const;
+const MODIFIERS = new Set<string>(MODIFIER_ORDER);
+const SPECIAL_KEYS = new Set<string>([
+  "escape",
+  "esc",
+  "enter",
+  "return",
+  "tab",
+  "space",
+  "backspace",
+  "delete",
+  "insert",
+  "clear",
+  "home",
+  "end",
+  "pageup",
+  "pagedown",
+  "up",
+  "down",
+  "left",
+  "right",
+  "f1",
+  "f2",
+  "f3",
+  "f4",
+  "f5",
+  "f6",
+  "f7",
+  "f8",
+  "f9",
+  "f10",
+  "f11",
+  "f12",
+]);
+const SYMBOL_KEYS = new Set<string>([
+  "`",
+  "-",
+  "=",
+  "[",
+  "]",
+  "\\",
+  ";",
+  "'",
+  ",",
+  ".",
+  "/",
+  "!",
+  "@",
+  "#",
+  "$",
+  "%",
+  "^",
+  "&",
+  "*",
+  "(",
+  ")",
+  "_",
+  "+",
+  "|",
+  "~",
+  "{",
+  "}",
+  ":",
+  "<",
+  ">",
+  "?",
+]);
+const DISPLAY_NAMES: Record<string, string> = {
+  escape: "Escape",
+  esc: "Esc",
+  enter: "Enter",
+  return: "Return",
+  tab: "Tab",
+  space: "Space",
+  backspace: "Backspace",
+  delete: "Delete",
+  insert: "Insert",
+  clear: "Clear",
+  home: "Home",
+  end: "End",
+  pageup: "PageUp",
+  pagedown: "PageDown",
+  up: "Up",
+  down: "Down",
+  left: "Left",
+  right: "Right",
+};
+
+export function normalizeShortcutKey(value: string | undefined): string | undefined {
+  const parts = parseShortcutParts(value);
+  if (!parts) {
+    return undefined;
+  }
+
+  const key = normalizeBaseKey(parts.key);
+  if (!key) {
+    return undefined;
+  }
+
+  const modifierSet = new Set<string>();
+  for (const modifier of parts.modifiers) {
+    if (!MODIFIERS.has(modifier) || modifierSet.has(modifier)) {
+      return undefined;
+    }
+    modifierSet.add(modifier);
+  }
+
+  const orderedModifiers = MODIFIER_ORDER.filter((modifier) => modifierSet.has(modifier));
+  return [...orderedModifiers, key].join("+");
+}
+
+type EffectiveKeybindings = Record<string, string | string[]>;
+
+export function validateShortcutKey(
+  value: string,
+  effectiveKeybindings?: EffectiveKeybindings
+): { normalized?: string; error?: string } {
+  const normalized = normalizeShortcutKey(value);
+  if (!normalized) {
+    return {
+      error: "Use a valid Pi key combo like Alt+P or Ctrl+Alt+P.",
+    };
+  }
+
+  const parts = normalized.split("+");
+  const hasCtrl = parts.includes("ctrl");
+  const hasAlt = parts.includes("alt");
+  if (!hasCtrl && !hasAlt) {
+    return {
+      error: "Promptsmith shortcuts must include Alt and/or Ctrl so normal typing keeps working.",
+    };
+  }
+
+  const conflictAction = effectiveKeybindings
+    ? findShortcutConflictAction(normalized, effectiveKeybindings)
+    : undefined;
+  if (conflictAction) {
+    return {
+      error: `That key is already used by Pi for ${conflictAction}. Pick a different shortcut.`,
+    };
+  }
+
+  return { normalized };
+}
+
+export function findShortcutConflictAction(
+  shortcutKey: string,
+  effectiveKeybindings: EffectiveKeybindings
+): string | undefined {
+  const normalized = normalizeShortcutKey(shortcutKey);
+  if (!normalized) {
+    return undefined;
+  }
+
+  for (const [action, keys] of Object.entries(effectiveKeybindings)) {
+    const keyList = Array.isArray(keys) ? keys : [keys];
+    if (keyList.some((key) => normalizeShortcutKey(key) === normalized)) {
+      return action;
+    }
+  }
+
+  return undefined;
+}
+
+export function formatShortcutKey(value: string | undefined): string {
+  const normalized = normalizeShortcutKey(value) ?? DEFAULT_SHORTCUT_KEY;
+  const parts = parseShortcutParts(normalized);
+  if (!parts) {
+    return formatShortcutKey(DEFAULT_SHORTCUT_KEY);
+  }
+
+  return [
+    ...parts.modifiers.map((modifier) => formatShortcutToken(modifier, false)),
+    formatShortcutToken(parts.key, true),
+  ].join("+");
+}
+
+export function isDefaultShortcutConfigured(settings: PromptsmithSettings): boolean {
+  return normalizeShortcutKey(settings.shortcutKey) === DEFAULT_SHORTCUT_KEY;
+}
+
+export function matchesCustomShortcut(
+  data: string,
+  settings: PromptsmithSettings,
+  effectiveKeybindings: EffectiveKeybindings
+): boolean {
+  if (!settings.enabled || !settings.shortcutEnabled) {
+    return false;
+  }
+
+  const shortcutKey = normalizeShortcutKey(settings.shortcutKey);
+  if (!shortcutKey || shortcutKey === DEFAULT_SHORTCUT_KEY) {
+    return false;
+  }
+
+  if (findShortcutConflictAction(shortcutKey, effectiveKeybindings)) {
+    return false;
+  }
+
+  return matchesKey(data, shortcutKey as KeyId);
+}
+
+function parseShortcutParts(
+  value: string | undefined
+): { modifiers: string[]; key: string } | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const parts =
+    trimmed === "+"
+      ? ["+"]
+      : trimmed.endsWith("+")
+        ? [
+            ...trimmed
+              .slice(0, -1)
+              .split("+")
+              .map((part) => part.trim())
+              .filter(Boolean),
+            "+",
+          ]
+        : trimmed
+            .split("+")
+            .map((part) => part.trim())
+            .filter(Boolean);
+  if (parts.length === 0) {
+    return undefined;
+  }
+
+  const key = parts.at(-1);
+  if (!key) {
+    return undefined;
+  }
+
+  return {
+    modifiers: parts.slice(0, -1),
+    key,
+  };
+}
+
+function normalizeBaseKey(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (/^[a-z0-9]$/.test(value)) {
+    return value;
+  }
+
+  if (SPECIAL_KEYS.has(value)) {
+    if (value === "return") return "enter";
+    if (value === "esc") return "escape";
+    return value;
+  }
+
+  return SYMBOL_KEYS.has(value) ? value : undefined;
+}
+
+function formatShortcutToken(token: string, isKey: boolean): string {
+  if (!isKey) {
+    return token.slice(0, 1).toUpperCase() + token.slice(1);
+  }
+
+  if (DISPLAY_NAMES[token]) {
+    return DISPLAY_NAMES[token];
+  }
+
+  if (/^[a-z]$/.test(token)) {
+    return token.toUpperCase();
+  }
+
+  if (/^f\d+$/.test(token)) {
+    return token.toUpperCase();
+  }
+
+  return token;
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -7,6 +7,7 @@ import {
   MAX_ENHANCEMENT_TIMEOUT_MS,
   MIN_ENHANCEMENT_TIMEOUT_MS,
 } from "./constants.js";
+import { normalizeShortcutKey } from "./shortcut-key.js";
 import { normalize } from "./model-routing.js";
 import type {
   ExactModelOverride,
@@ -95,6 +96,7 @@ export function sanitizeSettings(value: unknown): PromptsmithSettings | undefine
     version: DEFAULT_SETTINGS.version,
     enabled: readBoolean(value.enabled, DEFAULT_SETTINGS.enabled),
     shortcutEnabled: readBoolean(value.shortcutEnabled, DEFAULT_SETTINGS.shortcutEnabled),
+    shortcutKey: readShortcutKey(value.shortcutKey),
     targetFamilyMode: readTargetFamilyMode(value.targetFamilyMode),
     fallbackFamily: readFamily(value.fallbackFamily, DEFAULT_SETTINGS.fallbackFamily),
     exactModelOverrides: sanitizeExactOverrides(value.exactModelOverrides),
@@ -240,6 +242,14 @@ function readFamily<TFallback extends string | undefined>(
   fallback: TFallback
 ): "gpt" | "claude" | TFallback {
   return value === "gpt" || value === "claude" ? value : fallback;
+}
+
+function readShortcutKey(value: unknown): string {
+  if (typeof value !== "string") {
+    return DEFAULT_SETTINGS.shortcutKey;
+  }
+
+  return normalizeShortcutKey(value) ?? DEFAULT_SETTINGS.shortcutKey;
 }
 
 function readTargetFamilyMode(value: unknown): PromptsmithSettings["targetFamilyMode"] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export interface PromptsmithSettings {
   version: 1;
   enabled: boolean;
   shortcutEnabled: boolean;
+  shortcutKey: string;
   targetFamilyMode: PromptsmithTargetFamilyMode;
   fallbackFamily: PromptsmithFamily;
   exactModelOverrides: ExactModelOverride[];

--- a/src/ui/promptsmith-editor.ts
+++ b/src/ui/promptsmith-editor.ts
@@ -1,0 +1,31 @@
+import { CustomEditor, type KeybindingsManager } from "@mariozechner/pi-coding-agent";
+import type { EditorTheme, TUI } from "@mariozechner/pi-tui";
+import { matchesCustomShortcut } from "../shortcut-key.js";
+import type { PromptsmithSettings } from "../types.js";
+
+export class PromptsmithEditor extends CustomEditor {
+  constructor(
+    tui: TUI,
+    theme: EditorTheme,
+    private readonly promptsmithKeybindings: KeybindingsManager,
+    private readonly getSettings: () => PromptsmithSettings,
+    private readonly onPromptsmithShortcut: () => void
+  ) {
+    super(tui, theme, promptsmithKeybindings);
+  }
+
+  handleInput(data: string): void {
+    if (
+      matchesCustomShortcut(
+        data,
+        this.getSettings(),
+        this.promptsmithKeybindings.getEffectiveConfig()
+      )
+    ) {
+      this.onPromptsmithShortcut();
+      return;
+    }
+
+    super.handleInput(data);
+  }
+}

--- a/src/ui/settings-actions.ts
+++ b/src/ui/settings-actions.ts
@@ -18,9 +18,12 @@ import {
 } from "../overrides.js";
 import { cloneSettings } from "../state.js";
 import type { PromptsmithRuntimeState } from "../state.js";
+import { DEFAULT_SHORTCUT_KEY } from "../constants.js";
+import { formatShortcutKey, isDefaultShortcutConfigured } from "../shortcut-key.js";
 import type { ModelRef, PromptsmithFamily, PromptsmithSettings } from "../types.js";
 import { parseEnhancementTimeoutSeconds } from "../validation.js";
 import { openSelectDialog, type SelectDialogItem } from "./select-dialog.js";
+import { captureShortcutKey } from "./shortcut-capture.js";
 import {
   describeSelectedEnhancerMode,
   describeSelectedRewriteMode,
@@ -47,7 +50,6 @@ interface SettingsActionContext {
   ctx: ExtensionContext;
   runtime: PromptsmithRuntimeState;
   services: SettingsUiServices;
-  settings: PromptsmithSettings;
 }
 
 type SettingsChange = PromptsmithSettings | ((current: PromptsmithSettings) => PromptsmithSettings);
@@ -58,7 +60,8 @@ export async function runSettingsAction(
   choice: Exclude<SettingsMenuOptionId, "done">,
   options: SettingsActionContext
 ): Promise<void> {
-  const { ctx, runtime, services, settings } = options;
+  const { ctx, runtime, services } = options;
+  const settings = runtime.getSettings();
 
   switch (choice) {
     case "enabled":
@@ -70,15 +73,62 @@ export async function runSettingsAction(
         (next) => `Promptsmith is now ${next.enabled ? "on" : "off"}.`
       );
       return;
-    case "shortcutEnabled":
-      persistSettings(
+    case "shortcutEnabled": {
+      const shortcutChoice = await selectOption(
         ctx,
-        runtime,
-        services,
-        (latest) => ({ ...latest, shortcutEnabled: !latest.shortcutEnabled }),
-        (next) => `Keyboard shortcut is now ${next.shortcutEnabled ? "on" : "off"}.`
+        "Keyboard shortcut",
+        [
+          "Change keybinding",
+          `${settings.shortcutEnabled ? "Turn shortcut off" : "Turn shortcut on"}`,
+          ...(!isDefaultShortcutConfigured(settings) ? ["Reset to Alt+P"] : []),
+          "Back",
+        ],
+        "Back"
       );
-      return;
+
+      switch (shortcutChoice) {
+        case undefined:
+        case "Back":
+          return;
+        case "Change keybinding": {
+          const shortcutKey = await captureShortcutKey(ctx, {
+            currentValue: settings.shortcutKey,
+          });
+          if (!shortcutKey) {
+            return;
+          }
+          persistSettings(
+            ctx,
+            runtime,
+            services,
+            (latest) => ({ ...latest, shortcutEnabled: true, shortcutKey }),
+            `Keyboard shortcut set to ${formatShortcutKey(shortcutKey)}.`
+          );
+          return;
+        }
+        case "Turn shortcut off":
+        case "Turn shortcut on":
+          persistSettings(
+            ctx,
+            runtime,
+            services,
+            (latest) => ({ ...latest, shortcutEnabled: !latest.shortcutEnabled }),
+            (next) => `Keyboard shortcut is now ${next.shortcutEnabled ? "on" : "off"}.`
+          );
+          return;
+        case "Reset to Alt+P":
+          persistSettings(
+            ctx,
+            runtime,
+            services,
+            (latest) => ({ ...latest, shortcutKey: DEFAULT_SHORTCUT_KEY }),
+            "Keyboard shortcut reset to Alt+P."
+          );
+          return;
+        default:
+          return;
+      }
+    }
     case "targetFamilyMode": {
       const mode = await selectOption(
         ctx,

--- a/src/ui/settings-menu.ts
+++ b/src/ui/settings-menu.ts
@@ -1,4 +1,5 @@
 import type { SelectDialogItem } from "./select-dialog.js";
+import { formatShortcutKey } from "../shortcut-key.js";
 import type { ModelRef, PromptsmithSettings } from "../types.js";
 
 export type SettingsMenuOptionId =
@@ -60,13 +61,13 @@ export function buildSettingsMenuOptions(
       "enabled",
       "Prompt enhancement",
       onOff(settings.enabled),
-      "Master switch for /promptsmith and Alt+P."
+      "Master switch for /promptsmith and the keyboard shortcut."
     ),
     shortcutEnabled: createSettingsMenuItem(
       "shortcutEnabled",
-      "Keyboard shortcut (Alt+P)",
-      onOff(settings.shortcutEnabled),
-      "Run Promptsmith directly from the editor."
+      "Keyboard shortcut",
+      `${onOff(settings.shortcutEnabled)} · ${formatShortcutKey(settings.shortcutKey)}`,
+      "Run Promptsmith directly from the editor. Change the key combo or turn it off."
     ),
     statusBarEnabled: createSettingsMenuItem(
       "statusBarEnabled",

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -34,7 +34,7 @@ export async function openSettingsUi(
       return;
     }
 
-    await runSettingsAction(choice, { ctx, runtime, services, settings });
+    await runSettingsAction(choice, { ctx, runtime, services });
   }
 }
 

--- a/src/ui/shortcut-capture.ts
+++ b/src/ui/shortcut-capture.ts
@@ -1,0 +1,77 @@
+import { parseKey, truncateToWidth, type Component } from "@mariozechner/pi-tui";
+import type { ExtensionContext, KeybindingsManager } from "@mariozechner/pi-coding-agent";
+import { DEFAULT_SHORTCUT_KEY } from "../constants.js";
+import { formatShortcutKey, validateShortcutKey } from "../shortcut-key.js";
+
+export async function captureShortcutKey(
+  ctx: ExtensionContext,
+  options?: { currentValue?: string }
+): Promise<string | undefined> {
+  return ctx.ui.custom<string | undefined>((tui, theme, keybindings, done) => {
+    return new ShortcutCaptureDialog(theme, keybindings, {
+      ...(options?.currentValue ? { currentValue: options.currentValue } : {}),
+      requestRender: () => tui.requestRender(),
+      onDone: done,
+    });
+  });
+}
+
+type DialogTheme = Pick<ExtensionContext["ui"]["theme"], "fg" | "bold">;
+
+class ShortcutCaptureDialog implements Component {
+  private hint = "Press the new shortcut. Esc cancels.";
+
+  constructor(
+    private readonly theme: DialogTheme,
+    private readonly keybindings: KeybindingsManager,
+    private readonly callbacks: {
+      currentValue?: string;
+      requestRender: () => void;
+      onDone: (value: string | undefined) => void;
+    }
+  ) {}
+
+  invalidate(): void {
+    // No cached render state.
+  }
+
+  render(width: number): string[] {
+    return [
+      this.theme.fg("accent", truncateToWidth(this.theme.bold("Set Promptsmith shortcut"), width)),
+      this.theme.fg(
+        "dim",
+        truncateToWidth(
+          `Current: ${formatShortcutKey(this.callbacks.currentValue)} · Backspace resets to default`,
+          width
+        )
+      ),
+      this.theme.fg("text", truncateToWidth(this.hint, width)),
+    ];
+  }
+
+  handleInput(data: string): void {
+    const parsed = parseKey(data);
+    if (!parsed) {
+      return;
+    }
+
+    if (parsed === "escape") {
+      this.callbacks.onDone(undefined);
+      return;
+    }
+
+    if (parsed === "backspace" || parsed === "delete") {
+      this.callbacks.onDone(DEFAULT_SHORTCUT_KEY);
+      return;
+    }
+
+    const validation = validateShortcutKey(parsed, this.keybindings.getEffectiveConfig());
+    if (validation.normalized) {
+      this.callbacks.onDone(validation.normalized);
+      return;
+    }
+
+    this.hint = validation.error ?? "That shortcut is not valid.";
+    this.callbacks.requestRender();
+  }
+}

--- a/src/ui/status.ts
+++ b/src/ui/status.ts
@@ -1,5 +1,6 @@
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { EXTENSION_COMMAND, EXTENSION_NAME, MAX_STATUS_MODEL_ID_LENGTH } from "../constants.js";
+import { formatShortcutKey } from "../shortcut-key.js";
 import { buildEnhancerModeLabel } from "../enhance.js";
 import { analyzeDraftIntent } from "../intent.js";
 import { describeResolvedFamily, resolveTargetFamily } from "../model-routing.js";
@@ -72,6 +73,7 @@ export function buildStatusReport(ctx: ExtensionContext, runtime: PromptsmithRun
       : []),
     `enabled: ${settings.enabled}`,
     `shortcut enabled: ${settings.shortcutEnabled}`,
+    `shortcut key: ${formatShortcutKey(settings.shortcutKey)}`,
     `status bar enabled: ${settings.statusBarEnabled}`,
     `include recent conversation: ${settings.includeRecentConversation}`,
     `include project metadata: ${settings.includeProjectMetadata}`,

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -86,6 +86,30 @@ void test("shortcut with empty editor opens settings", async () => {
   assert.deepEqual(ctx.uiState.selectTitles, ["Promptsmith settings"]);
 });
 
+void test("configured shortcut still enhances when invoked through the custom editor path", async () => {
+  const runtime = createRuntimeState();
+  const harness = createMockPi();
+  const ctx = createCommandContext({
+    model: createModel(),
+    editorText: "rough draft",
+  });
+
+  runtime.replaceSettings({
+    ...runtime.getSettings(),
+    shortcutKey: "ctrl+alt+p",
+  });
+
+  await handlePromptsmithShortcut(
+    ctx,
+    runtime,
+    createShortcutServices(harness, ctx, () =>
+      Promise.resolve(createCompleteResponse("Sharper prompt"))
+    )
+  );
+
+  assert.equal(ctx.uiState.editorText, "Sharper prompt");
+});
+
 void test("shortcut expands Pi paste markers from the clipboard before enhancement", async () => {
   const runtime = createRuntimeState();
   const ctx = createCommandContext({
@@ -125,11 +149,12 @@ void test("settings ui shows clearer labels and the footer status toggle", async
 
   const firstMenu = ctx.uiState.customOptionsHistory[0] ?? [];
   assert.ok(firstMenu.some((option) => /Prompt enhancement · On/i.test(option)));
+  assert.ok(firstMenu.some((option) => /Keyboard shortcut · On · Alt\+P/i.test(option)));
   assert.ok(firstMenu.some((option) => /Footer status bar · Off/i.test(option)));
   assert.ok(firstMenu.some((option) => /Rewrite mode · Auto/i.test(option)));
 
   const initialRender = ctx.uiState.customRenderHistory[0]?.join("\n") ?? "";
-  assert.match(initialRender, /Master switch for \/promptsmith and Alt\+P/i);
+  assert.match(initialRender, /Master switch for \/promptsmith and the keyboard shortcut/i);
 });
 
 void test("default enhancement skips recent conversation context for speed", async () => {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,8 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { EXTENSION_COMMAND, SHORTCUT_KEY } from "../src/constants.js";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_SETTINGS, DEFAULT_SHORTCUT_KEY, EXTENSION_COMMAND } from "../src/constants.js";
 import { createPromptsmithExtension } from "../src/index.js";
-import { createMockPi } from "./helpers.js";
+import { createCommandContext, createMockPi } from "./helpers.js";
 
 void test("extension registers the promptsmith command and shortcut", () => {
   const harness = createMockPi();
@@ -10,6 +13,51 @@ void test("extension registers the promptsmith command and shortcut", () => {
   createPromptsmithExtension(harness.pi);
 
   assert.ok(harness.commands.has(EXTENSION_COMMAND));
-  assert.ok(harness.shortcuts.has(SHORTCUT_KEY));
+  assert.ok(harness.shortcuts.has(DEFAULT_SHORTCUT_KEY));
   assert.ok(!("toolName" in harness));
+});
+
+void test("default shortcut does not ignore disabled custom shortcut settings", async () => {
+  const originalHome = process.env.HOME;
+  const tempHome = mkdtempSync(join(tmpdir(), "promptsmith-home-"));
+  process.env.HOME = tempHome;
+
+  try {
+    const settingsPath = join(tempHome, ".pi", "agent", "promptsmith-settings.json");
+    mkdirSync(join(tempHome, ".pi", "agent"), { recursive: true });
+    writeFileSync(
+      settingsPath,
+      `${JSON.stringify(
+        {
+          ...DEFAULT_SETTINGS,
+          shortcutKey: "ctrl+alt+p",
+          shortcutEnabled: false,
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+
+    const harness = createMockPi();
+    createPromptsmithExtension(harness.pi);
+
+    const ctx = createCommandContext({ editorText: "draft" });
+    const sessionStartHandlers = harness.events.get("session_start") ?? [];
+    for (const handler of sessionStartHandlers) {
+      await handler({}, ctx);
+    }
+
+    await harness.shortcuts.get(DEFAULT_SHORTCUT_KEY)?.handler(ctx);
+
+    const messages = ctx.uiState.notifications.map((entry) => entry.message).join("\n");
+    assert.match(messages, /shortcut is disabled globally/i);
+    assert.doesNotMatch(messages, /shortcut is now ctrl\+alt\+p/i);
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+  }
 });

--- a/test/shortcut-settings.test.ts
+++ b/test/shortcut-settings.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  findShortcutConflictAction,
+  formatShortcutKey,
+  normalizeShortcutKey,
+  validateShortcutKey,
+} from "../src/shortcut-key.js";
+import { buildStatusReport } from "../src/ui/status.js";
+import { createCommandContext, createRuntimeState } from "./helpers.js";
+
+void test("shortcut keys normalize into Pi's canonical format", () => {
+  assert.equal(normalizeShortcutKey(" Alt + Shift + P "), "shift+alt+p");
+  assert.equal(normalizeShortcutKey("CTRL+return"), "ctrl+enter");
+  assert.equal(normalizeShortcutKey("ctrl++"), "ctrl++");
+  assert.equal(normalizeShortcutKey("bogus+key"), undefined);
+});
+
+void test("shortcut validation rejects plain typing keys and Pi conflicts", () => {
+  assert.match(validateShortcutKey("p").error ?? "", /must include alt and\/or ctrl/i);
+  assert.match(
+    validateShortcutKey("ctrl+p", { cycleModelForward: "ctrl+p" }).error ?? "",
+    /already used by pi/i
+  );
+  assert.equal(validateShortcutKey("ctrl+alt+p").normalized, "ctrl+alt+p");
+});
+
+void test("shortcut conflict lookup finds matching built-in actions", () => {
+  assert.equal(
+    findShortcutConflictAction("ctrl+p", { cycleModelForward: ["ctrl+p", "f7"] }),
+    "cycleModelForward"
+  );
+  assert.equal(findShortcutConflictAction("alt+p", { submit: "enter" }), undefined);
+});
+
+void test("status report includes the configured shortcut key", () => {
+  const runtime = createRuntimeState();
+  runtime.replaceSettings({
+    ...runtime.getSettings(),
+    shortcutKey: "ctrl+alt+p",
+  });
+  const ctx = createCommandContext();
+
+  const report = buildStatusReport(ctx, runtime);
+
+  assert.match(report, /shortcut key: Ctrl\+Alt\+P/);
+  assert.equal(formatShortcutKey("ctrl+alt+p"), "Ctrl+Alt+P");
+  assert.equal(formatShortcutKey("ctrl++"), "Ctrl++");
+});

--- a/test/state-and-routing.test.ts
+++ b/test/state-and-routing.test.ts
@@ -203,6 +203,7 @@ void test("settings persist across sessions globally", () => {
     ...runtime.getSettings(),
     enabled: false,
     statusBarEnabled: true,
+    shortcutKey: "ctrl+alt+p",
     rewriteMode: "plain",
     enhancementTimeoutMs: 12_000,
   });
@@ -212,6 +213,7 @@ void test("settings persist across sessions globally", () => {
 
   assert.equal(restoredRuntime.getSettings().enabled, false);
   assert.equal(restoredRuntime.getSettings().statusBarEnabled, true);
+  assert.equal(restoredRuntime.getSettings().shortcutKey, "ctrl+alt+p");
   assert.equal(restoredRuntime.getSettings().rewriteMode, "plain");
   assert.equal(restoredRuntime.getSettings().enhancementTimeoutMs, 12_000);
 });
@@ -236,6 +238,14 @@ void test("failed global settings writes do not claim success or corrupt runtime
 
 void test("sanitizeSettings rejects unknown schema versions", () => {
   assert.equal(sanitizeSettings({ version: 2 }), undefined);
+});
+
+void test("sanitizeSettings normalizes shortcut keys and falls back on invalid values", () => {
+  const normalized = sanitizeSettings({ version: 1, shortcutKey: "Alt + Shift + P" });
+  const fallback = sanitizeSettings({ version: 1, shortcutKey: "plain-p" });
+
+  assert.equal(normalized?.shortcutKey, "shift+alt+p");
+  assert.equal(fallback?.shortcutKey, "alt+p");
 });
 
 void test("sanitizeSettings dedupes exact and pattern overrides by normalized key", () => {

--- a/test/ui-and-enhance-ux.test.ts
+++ b/test/ui-and-enhance-ux.test.ts
@@ -288,7 +288,6 @@ void test("clearing the fixed enhancer model in fixed mode falls back to active 
     services: {
       refreshStatus: () => undefined,
     },
-    settings: runtime.getSettings(),
   });
 
   assert.equal(runtime.getSettings().enhancerModelMode, "active");
@@ -346,7 +345,6 @@ void test("exact override manual routing picker omits the Clear option", async (
     services: {
       refreshStatus: () => undefined,
     },
-    settings: runtime.getSettings(),
   });
 
   assert.equal(
@@ -423,7 +421,6 @@ void test("exact override removal clears case-variant duplicates and uses the ra
         refreshCount += 1;
       },
     },
-    settings: runtime.getSettings(),
   });
 
   assert.deepEqual(removeRuleOptions[0], {
@@ -438,7 +435,6 @@ void test("exact override removal clears case-variant duplicates and uses the ra
 
 void test("settings actions persist against the latest runtime snapshot", async () => {
   const runtime = createRuntimeState();
-  const staleSettings = runtime.getSettings();
   runtime.replaceSettings({ ...runtime.getSettings(), statusBarEnabled: true });
 
   const ctx = createCommandContext();
@@ -449,7 +445,6 @@ void test("settings actions persist against the latest runtime snapshot", async 
     services: {
       refreshStatus: () => undefined,
     },
-    settings: staleSettings,
   });
 
   assert.equal(runtime.getSettings().enabled, false);
@@ -474,7 +469,6 @@ void test("settings actions report persistence failures without throwing", async
         refreshCount += 1;
       },
     },
-    settings: runtime.getSettings(),
   });
 
   assert.deepEqual(runtime.getSettings(), previousSettings);
@@ -546,7 +540,6 @@ void test("pattern override removal uses the raw pattern value and clears case-v
     services: {
       refreshStatus: () => undefined,
     },
-    settings: runtime.getSettings(),
   });
 
   assert.deepEqual(removeRuleOptions[1], {


### PR DESCRIPTION
## Summary\n- add persisted Promptsmith shortcut settings, remapping UI, and custom-editor handling for non-default bindings\n- show the configured shortcut in status/settings/docs and cover the new behavior with tests\n- fix the default Alt+P path so disabled custom shortcuts still respect saved state, and remove stale settings-action state\n\n## Verification\n- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Customizable keyboard shortcut: remap the default Alt+P to any key combination
  * Enhanced settings panel: toggle shortcut on/off, remap keys, or reset to defaults
  * Shortcut capture interface with validation and conflict prevention

* **Documentation**
  * Updated Quick Start guide with keyboard shortcut configuration details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->