### PR TITLE
feat(promptsmith): align GPT rewrites with OpenAI guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* **promptsmith:** align GPT-style rewrites with OpenAI prompt guidance and request concise GPT enhancer output
+
+### Bug Fixes
+
+* **promptsmith:** preserve existing custom editor components when installing the Promptsmith shortcut wrapper
+
 ## [0.3.2](https://github.com/ayagmar/pi-promptsmith/compare/v0.3.1...v0.3.2) (2026-05-11)
 
 ## [0.3.1](https://github.com/ayagmar/pi-promptsmith/compare/v0.3.0...v0.3.1) (2026-03-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-* **promptsmith:** align GPT-style rewrites with OpenAI prompt guidance and request concise GPT enhancer output
+* **promptsmith:** align GPT-style rewrites with OpenAI prompt guidance and request concise Codex Responses enhancer output
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ It is intentionally **not** a giant fixed template. Promptsmith keeps concrete u
 
 Family-aware behavior still applies:
 
-- **GPT-style** rewrites stay natural and compact
+- **GPT-style** rewrites follow OpenAI prompt guidance: outcome-first, compact, explicit about success criteria/constraints/output/stop rules when useful, and light on process scaffolding
 - **Claude-style** rewrites can use stronger structure, including XML-like sections when that genuinely helps
 
 ## Examples
@@ -294,6 +294,7 @@ Promptsmith keeps a few important guarantees:
 - only one enhancement runs at a time
 - output must contain exactly one sentinel block
 - invalid model-output failures say whether the model missed the sentinel, emitted multiple blocks, added extra text, or returned an empty block
+- GPT enhancer calls request concise text output where the Pi/OpenAI provider supports verbosity controls
 - a bad first model response is retried once with a stricter format reminder before Promptsmith fails closed
 - single collapsed Pi paste markers can be recovered from the clipboard; multi-marker drafts fail closed
 - oversized drafts fail clearly instead of being truncated silently

--- a/src/enhance.ts
+++ b/src/enhance.ts
@@ -377,9 +377,25 @@ function buildCompletionOptions(
   return {
     ...(typeof apiKey === "string" ? { apiKey } : {}),
     ...(headers ? { headers } : {}),
+    ...buildGptCompletionOptions(preparation.enhancerModel.model),
     signal: requestSignal,
     maxTokens: Math.min(preparation.enhancerModel.model.maxTokens, ENHANCER_MAX_OUTPUT_TOKENS),
   };
+}
+
+function buildGptCompletionOptions(model: Model<Api>): CompleteOptions {
+  return isGptModel(model) ? { textVerbosity: "low" } : {};
+}
+
+function isGptModel(model: Model<Api>): boolean {
+  const provider = model.provider.toLowerCase();
+  const id = model.id.toLowerCase();
+  return (
+    provider === "openai" ||
+    provider === "openai-codex" ||
+    id.startsWith("gpt") ||
+    /^o[1-9]/.test(id)
+  );
 }
 
 function buildRetryRequest(request: Context): Context {

--- a/src/enhance.ts
+++ b/src/enhance.ts
@@ -384,7 +384,11 @@ function buildCompletionOptions(
 }
 
 function buildGptCompletionOptions(model: Model<Api>): CompleteOptions {
-  return isGptModel(model) ? { textVerbosity: "low" } : {};
+  if (!isGptModel(model)) {
+    return {};
+  }
+
+  return model.api === "openai-codex-responses" ? { textVerbosity: "low" } : {};
 }
 
 function isGptModel(model: Model<Api>): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { runEnhancementWithLoader } from "./enhance.js";
 import { formatShortcutKey, getCustomShortcutKey } from "./shortcut-key.js";
 import { PromptsmithRuntimeState } from "./state.js";
 import { handlePromptsmithShortcut } from "./shortcut.js";
-import { PromptsmithEditor } from "./ui/promptsmith-editor.js";
+import { attachPromptsmithShortcut, createBasePromptsmithEditor } from "./ui/promptsmith-editor.js";
 import { openSettingsUi } from "./ui/settings.js";
 import { refreshStatusLine } from "./ui/status.js";
 
@@ -21,6 +21,7 @@ export function createPromptsmithExtension(
 ): void {
   const runtime = new PromptsmithRuntimeState();
   let ownsEditorComponent = false;
+  let previousEditorFactory: ReturnType<ExtensionContext["ui"]["getEditorComponent"]>;
   let installedCustomShortcutKey: string | undefined;
   let activeCustomShortcutKey: string | undefined;
 
@@ -31,7 +32,8 @@ export function createPromptsmithExtension(
       return;
     }
 
-    ctx.ui.setEditorComponent(undefined);
+    ctx.ui.setEditorComponent(previousEditorFactory);
+    previousEditorFactory = undefined;
     ownsEditorComponent = false;
   };
 
@@ -50,8 +52,13 @@ export function createPromptsmithExtension(
       return;
     }
 
+    const baseEditorFactory = ownsEditorComponent
+      ? previousEditorFactory
+      : ctx.ui.getEditorComponent();
+
     installedCustomShortcutKey = shortcutKey;
     activeCustomShortcutKey = undefined;
+    previousEditorFactory = baseEditorFactory;
     ownsEditorComponent = true;
     ctx.ui.setEditorComponent((tui, theme, keybindings) => {
       activeCustomShortcutKey = getCustomShortcutKey(
@@ -59,9 +66,12 @@ export function createPromptsmithExtension(
         keybindings.getEffectiveConfig()
       );
 
-      return new PromptsmithEditor(
-        tui,
-        theme,
+      const baseEditor =
+        baseEditorFactory?.(tui, theme, keybindings) ??
+        createBasePromptsmithEditor(tui, theme, keybindings);
+
+      return attachPromptsmithShortcut(
+        baseEditor,
         keybindings,
         () => runtime.getSettings(),
         () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,9 @@ export default function promptsmithExtension(pi: ExtensionAPI): void {
 
 export function createPromptsmithExtension(
   pi: ExtensionAPI,
-  options?: { completeFn?: CompleteFn }
+  options?: { completeFn?: CompleteFn; runtime?: PromptsmithRuntimeState }
 ): void {
-  const runtime = new PromptsmithRuntimeState();
+  const runtime = options?.runtime ?? new PromptsmithRuntimeState();
   let ownsEditorComponent = false;
   let previousEditorFactory: ReturnType<ExtensionContext["ui"]["getEditorComponent"]>;
   let installedCustomShortcutKey: string | undefined;

--- a/src/strategies/gpt.ts
+++ b/src/strategies/gpt.ts
@@ -3,6 +3,22 @@ import { buildStrategyInstructions } from "../contracts.js";
 import { buildSharedContextSections, buildSharedSystemPrompt } from "./shared.js";
 import type { PromptsmithContextPayload } from "../types.js";
 
+const GPT_SYSTEM_GUIDANCE = [
+  "For GPT-target rewrites, apply OpenAI prompt guidance: make the generated prompt outcome-first, compact, explicit about success criteria, and only as structured as the task needs.",
+  "Prefer decision rules over process-heavy step stacks; reserve absolute words like always, never, must, and only for true invariants.",
+  "Use grounding, retrieval budgets, citations, and validation checks only when they materially fit the user's task.",
+];
+
+const GPT_PROMPT_GUIDANCE = [
+  "Apply OpenAI GPT prompt guidance to the rewrite:",
+  "- State the desired outcome first, then add success criteria, constraints, available context, output shape, and stop rules only when they change behavior.",
+  "- Keep the prompt as short as possible while preserving the product contract; remove duplicate, contradictory, or legacy process scaffolding.",
+  "- Use plain Markdown sections or paragraphs by default. Avoid XML-heavy structure unless the draft already uses it or stable parsing requires it.",
+  "- Preserve the requested artifact, length, structure, genre, and concrete details before improving style.",
+  "- For grounded factual work, define evidence boundaries, citation behavior, missing-evidence handling, and a retrieval budget.",
+  "- For coding-agent work, make tool boundaries, inspection scope, expected edits, verification, and failure behavior clear without scripting every internal step.",
+];
+
 export function buildGptStrategyRequest(context: PromptsmithContextPayload): Context {
   const userMessage: Message = {
     role: "user",
@@ -11,6 +27,7 @@ export function buildGptStrategyRequest(context: PromptsmithContextPayload): Con
       {
         type: "text",
         text: [
+          ...GPT_PROMPT_GUIDANCE,
           ...buildStrategyInstructions("gpt", context),
           buildSharedContextSections(context),
         ].join("\n\n"),
@@ -19,7 +36,7 @@ export function buildGptStrategyRequest(context: PromptsmithContextPayload): Con
   };
 
   return {
-    systemPrompt: buildSharedSystemPrompt("GPT-style"),
+    systemPrompt: buildSharedSystemPrompt("GPT-style", GPT_SYSTEM_GUIDANCE),
     messages: [userMessage],
   };
 }

--- a/src/strategies/shared.ts
+++ b/src/strategies/shared.ts
@@ -1,7 +1,10 @@
 import { buildSentinelReminder } from "../parser.js";
 import type { PromptsmithContextPayload } from "../types.js";
 
-export function buildSharedSystemPrompt(targetStyle: "GPT-style" | "Claude-style"): string {
+export function buildSharedSystemPrompt(
+  targetStyle: "GPT-style" | "Claude-style",
+  extraInstructions: string[] = []
+): string {
   return [
     `You are Promptsmith, an expert ${targetStyle} prompt rewriter.`,
     "Follow the resolved rewrite mode from the provided context.",
@@ -12,6 +15,7 @@ export function buildSharedSystemPrompt(targetStyle: "GPT-style" | "Claude-style
     "Do not invent facts, requirements, files, commands, or context that the user did not provide.",
     "Avoid speculative implementation details, generic filler, and duplicated sections.",
     "Keep the output concise and natural for the target model family.",
+    ...extraInstructions,
     "Do not add commentary about your rewrite.",
     "Do not use tools.",
     buildSentinelReminder(),

--- a/src/ui/promptsmith-editor.ts
+++ b/src/ui/promptsmith-editor.ts
@@ -1,31 +1,32 @@
 import { CustomEditor, type KeybindingsManager } from "@earendil-works/pi-coding-agent";
-import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
+import type { EditorComponent, EditorTheme, TUI } from "@earendil-works/pi-tui";
 import { matchesCustomShortcut } from "../shortcut-key.js";
 import type { PromptsmithSettings } from "../types.js";
 
-export class PromptsmithEditor extends CustomEditor {
-  constructor(
-    tui: TUI,
-    theme: EditorTheme,
-    private readonly promptsmithKeybindings: KeybindingsManager,
-    private readonly getSettings: () => PromptsmithSettings,
-    private readonly onPromptsmithShortcut: () => void
-  ) {
-    super(tui, theme, promptsmithKeybindings);
-  }
+export function createBasePromptsmithEditor(
+  tui: TUI,
+  theme: EditorTheme,
+  keybindings: KeybindingsManager
+): EditorComponent {
+  return new CustomEditor(tui, theme, keybindings);
+}
 
-  handleInput(data: string): void {
-    if (
-      matchesCustomShortcut(
-        data,
-        this.getSettings(),
-        this.promptsmithKeybindings.getEffectiveConfig()
-      )
-    ) {
-      this.onPromptsmithShortcut();
+export function attachPromptsmithShortcut(
+  editor: EditorComponent,
+  keybindings: KeybindingsManager,
+  getSettings: () => PromptsmithSettings,
+  onPromptsmithShortcut: () => void
+): EditorComponent {
+  const handleBaseInput = editor.handleInput.bind(editor);
+
+  editor.handleInput = (data: string): void => {
+    if (matchesCustomShortcut(data, getSettings(), keybindings.getEffectiveConfig())) {
+      onPromptsmithShortcut();
       return;
     }
 
-    super.handleInput(data);
-  }
+    handleBaseInput(data);
+  };
+
+  return editor;
 }

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -75,6 +75,50 @@ void test("promptsmith command forwards model request headers to the enhancer", 
   assert.deepEqual(requestOptions?.headers, { "x-promptsmith-test": "1" });
 });
 
+void test("promptsmith command asks GPT enhancer models for concise text", async () => {
+  const runtime = createRuntimeState();
+  const harness = createMockPi();
+  const model = createModel({ provider: "openai", id: "gpt-5.5" });
+  const ctx = createCommandContext({ model, allModels: [model], editorText: "fix this prompt" });
+  let requestOptions: Record<string, unknown> | undefined;
+
+  await handlePromptsmithCommand(
+    "",
+    ctx,
+    runtime,
+    createServices(harness, (_model, _context, options) => {
+      requestOptions = options;
+      return Promise.resolve(createCompleteResponse("Enhanced prompt"));
+    })
+  );
+
+  assert.equal(requestOptions?.textVerbosity, "low");
+});
+
+void test("promptsmith command does not add GPT-only request options to Claude enhancers", async () => {
+  const runtime = createRuntimeState();
+  const harness = createMockPi();
+  const model = createModel({
+    provider: "anthropic",
+    id: "claude-sonnet-4-5",
+    api: "anthropic-messages",
+  });
+  const ctx = createCommandContext({ model, allModels: [model], editorText: "fix this prompt" });
+  let requestOptions: Record<string, unknown> | undefined;
+
+  await handlePromptsmithCommand(
+    "",
+    ctx,
+    runtime,
+    createServices(harness, (_model, _context, options) => {
+      requestOptions = options;
+      return Promise.resolve(createCompleteResponse("Enhanced prompt"));
+    })
+  );
+
+  assert.equal(requestOptions?.textVerbosity, undefined);
+});
+
 void test("empty editor opens settings instead of failing", async () => {
   const runtime = createRuntimeState();
   const harness = createMockPi();

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -75,10 +75,14 @@ void test("promptsmith command forwards model request headers to the enhancer", 
   assert.deepEqual(requestOptions?.headers, { "x-promptsmith-test": "1" });
 });
 
-void test("promptsmith command asks GPT enhancer models for concise text", async () => {
+void test("promptsmith command asks Codex Responses enhancer models for concise text", async () => {
   const runtime = createRuntimeState();
   const harness = createMockPi();
-  const model = createModel({ provider: "openai", id: "gpt-5.5" });
+  const model = createModel({
+    provider: "openai-codex",
+    id: "gpt-5.5",
+    api: "openai-codex-responses",
+  });
   const ctx = createCommandContext({ model, allModels: [model], editorText: "fix this prompt" });
   let requestOptions: Record<string, unknown> | undefined;
 
@@ -93,6 +97,26 @@ void test("promptsmith command asks GPT enhancer models for concise text", async
   );
 
   assert.equal(requestOptions?.textVerbosity, "low");
+});
+
+void test("promptsmith command does not add Codex-only options to OpenAI Responses enhancers", async () => {
+  const runtime = createRuntimeState();
+  const harness = createMockPi();
+  const model = createModel({ provider: "openai", id: "gpt-5.5", api: "openai-responses" });
+  const ctx = createCommandContext({ model, allModels: [model], editorText: "fix this prompt" });
+  let requestOptions: Record<string, unknown> | undefined;
+
+  await handlePromptsmithCommand(
+    "",
+    ctx,
+    runtime,
+    createServices(harness, (_model, _context, options) => {
+      requestOptions = options;
+      return Promise.resolve(createCompleteResponse("Enhanced prompt"));
+    })
+  );
+
+  assert.equal(requestOptions?.textVerbosity, undefined);
 });
 
 void test("promptsmith command does not add GPT-only request options to Claude enhancers", async () => {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -104,6 +104,61 @@ void test("custom editor is not reinstalled when the shortcut setting is unchang
   }
 });
 
+void test("session shutdown restores an existing custom editor component", async () => {
+  const originalHome = process.env.HOME;
+  const tempHome = mkdtempSync(join(tmpdir(), "promptsmith-home-"));
+  process.env.HOME = tempHome;
+
+  try {
+    const settingsPath = join(tempHome, ".pi", "agent", "promptsmith-settings.json");
+    mkdirSync(join(tempHome, ".pi", "agent"), { recursive: true });
+    writeFileSync(
+      settingsPath,
+      `${JSON.stringify(
+        {
+          ...DEFAULT_SETTINGS,
+          shortcutKey: "ctrl+alt+p",
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+
+    const existingFactory = () => ({
+      render: () => [],
+      invalidate: () => undefined,
+      handleInput: () => undefined,
+      getText: () => "",
+      setText: () => undefined,
+    });
+    const harness = createMockPi();
+    createPromptsmithExtension(harness.pi);
+
+    const ctx = createCommandContext({
+      editorText: "draft",
+      editorComponentFactory: existingFactory,
+    });
+    for (const handler of harness.events.get("session_start") ?? []) {
+      await handler({}, ctx);
+    }
+    assert.notEqual(ctx.ui.getEditorComponent(), existingFactory);
+
+    for (const handler of harness.events.get("session_shutdown") ?? []) {
+      await handler({}, ctx);
+    }
+
+    assert.equal(ctx.ui.getEditorComponent(), existingFactory);
+    assert.deepEqual(ctx.uiState.editorComponentHistory, ["set", "set"]);
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+  }
+});
+
 void test("session shutdown clears the custom editor component", async () => {
   const originalHome = process.env.HOME;
   const tempHome = mkdtempSync(join(tmpdir(), "promptsmith-home-"));

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { DEFAULT_SHORTCUT_KEY, EXTENSION_COMMAND } from "../src/constants.js";
 import { createPromptsmithExtension } from "../src/index.js";
-import { createCommandContext, createMockPi, withPersistedSettings } from "./helpers.js";
+import { createCommandContext, createMockPi, createPersistedRuntimeState } from "./helpers.js";
 
 void test("extension registers the promptsmith command and shortcut", () => {
   const harness = createMockPi();
@@ -15,93 +15,92 @@ void test("extension registers the promptsmith command and shortcut", () => {
 });
 
 void test("default shortcut does not ignore disabled custom shortcut settings", async () => {
-  await withPersistedSettings({ shortcutKey: "ctrl+alt+p", shortcutEnabled: false }, async () => {
-    const harness = createMockPi();
-    createPromptsmithExtension(harness.pi);
-
-    const ctx = createCommandContext({ editorText: "draft" });
-    const sessionStartHandlers = harness.events.get("session_start") ?? [];
-    for (const handler of sessionStartHandlers) {
-      await handler({}, ctx);
-    }
-
-    await harness.shortcuts.get(DEFAULT_SHORTCUT_KEY)?.handler(ctx);
-
-    const messages = ctx.uiState.notifications.map((entry) => entry.message).join("\n");
-    assert.match(messages, /shortcut is disabled globally/i);
-    assert.doesNotMatch(messages, /shortcut is now ctrl\+alt\+p/i);
+  const harness = createMockPi();
+  const runtime = createPersistedRuntimeState({
+    shortcutKey: "ctrl+alt+p",
+    shortcutEnabled: false,
   });
+  createPromptsmithExtension(harness.pi, { runtime });
+
+  const ctx = createCommandContext({ editorText: "draft" });
+  const sessionStartHandlers = harness.events.get("session_start") ?? [];
+  for (const handler of sessionStartHandlers) {
+    await handler({}, ctx);
+  }
+
+  await harness.shortcuts.get(DEFAULT_SHORTCUT_KEY)?.handler(ctx);
+
+  const messages = ctx.uiState.notifications.map((entry) => entry.message).join("\n");
+  assert.match(messages, /shortcut is disabled globally/i);
+  assert.doesNotMatch(messages, /shortcut is now ctrl\+alt\+p/i);
 });
 
 void test("custom editor is not reinstalled when the shortcut setting is unchanged", async () => {
-  await withPersistedSettings({ shortcutKey: "ctrl+alt+p" }, async () => {
-    const harness = createMockPi();
-    createPromptsmithExtension(harness.pi);
+  const harness = createMockPi();
+  const runtime = createPersistedRuntimeState({ shortcutKey: "ctrl+alt+p" });
+  createPromptsmithExtension(harness.pi, { runtime });
 
-    const ctx = createCommandContext({ editorText: "draft" });
-    for (const handler of harness.events.get("session_start") ?? []) {
-      await handler({}, ctx);
-    }
-    for (const handler of harness.events.get("model_select") ?? []) {
-      await handler({}, ctx);
-    }
+  const ctx = createCommandContext({ editorText: "draft" });
+  for (const handler of harness.events.get("session_start") ?? []) {
+    await handler({}, ctx);
+  }
+  for (const handler of harness.events.get("model_select") ?? []) {
+    await handler({}, ctx);
+  }
 
-    assert.equal(ctx.uiState.editorComponentHistory.length, 1);
-    assert.equal(ctx.uiState.editorComponentHistory[0]?.kind, "set");
-  });
+  assert.equal(ctx.uiState.editorComponentHistory.length, 1);
+  assert.equal(ctx.uiState.editorComponentHistory[0]?.kind, "set");
 });
 
 void test("session shutdown restores an existing custom editor component", async () => {
-  await withPersistedSettings({ shortcutKey: "ctrl+alt+p" }, async () => {
-    const existingFactory = () => ({
-      render: () => [],
-      invalidate: () => undefined,
-      handleInput: () => undefined,
-      getText: () => "",
-      setText: () => undefined,
-    });
-    const harness = createMockPi();
-    createPromptsmithExtension(harness.pi);
-
-    const ctx = createCommandContext({
-      editorText: "draft",
-      editorComponentFactory: existingFactory,
-    });
-    for (const handler of harness.events.get("session_start") ?? []) {
-      await handler({}, ctx);
-    }
-    assert.notEqual(ctx.ui.getEditorComponent(), existingFactory);
-
-    for (const handler of harness.events.get("session_shutdown") ?? []) {
-      await handler({}, ctx);
-    }
-
-    const history = ctx.uiState.editorComponentHistory;
-    assert.equal(ctx.ui.getEditorComponent(), existingFactory);
-    assert.equal(history.length, 2);
-    assert.equal(history[0]?.kind, "set");
-    assert.equal(history[1]?.kind, "set");
-    assert.notEqual(history[0]?.kind === "set" ? history[0].factory : undefined, existingFactory);
-    assert.equal(history[1]?.kind === "set" ? history[1].factory : undefined, existingFactory);
+  const existingFactory = () => ({
+    render: () => [],
+    invalidate: () => undefined,
+    handleInput: () => undefined,
+    getText: () => "",
+    setText: () => undefined,
   });
+  const harness = createMockPi();
+  const runtime = createPersistedRuntimeState({ shortcutKey: "ctrl+alt+p" });
+  createPromptsmithExtension(harness.pi, { runtime });
+
+  const ctx = createCommandContext({
+    editorText: "draft",
+    editorComponentFactory: existingFactory,
+  });
+  for (const handler of harness.events.get("session_start") ?? []) {
+    await handler({}, ctx);
+  }
+  assert.notEqual(ctx.ui.getEditorComponent(), existingFactory);
+
+  for (const handler of harness.events.get("session_shutdown") ?? []) {
+    await handler({}, ctx);
+  }
+
+  const history = ctx.uiState.editorComponentHistory;
+  assert.equal(ctx.ui.getEditorComponent(), existingFactory);
+  assert.equal(history.length, 2);
+  assert.equal(history[0]?.kind, "set");
+  assert.equal(history[1]?.kind, "set");
+  assert.notEqual(history[0]?.kind === "set" ? history[0].factory : undefined, existingFactory);
+  assert.equal(history[1]?.kind === "set" ? history[1].factory : undefined, existingFactory);
 });
 
 void test("session shutdown clears the custom editor component", async () => {
-  await withPersistedSettings({ shortcutKey: "ctrl+alt+p" }, async () => {
-    const harness = createMockPi();
-    createPromptsmithExtension(harness.pi);
+  const harness = createMockPi();
+  const runtime = createPersistedRuntimeState({ shortcutKey: "ctrl+alt+p" });
+  createPromptsmithExtension(harness.pi, { runtime });
 
-    const ctx = createCommandContext({ editorText: "draft" });
-    for (const handler of harness.events.get("session_start") ?? []) {
-      await handler({}, ctx);
-    }
-    for (const handler of harness.events.get("session_shutdown") ?? []) {
-      await handler({}, ctx);
-    }
+  const ctx = createCommandContext({ editorText: "draft" });
+  for (const handler of harness.events.get("session_start") ?? []) {
+    await handler({}, ctx);
+  }
+  for (const handler of harness.events.get("session_shutdown") ?? []) {
+    await handler({}, ctx);
+  }
 
-    assert.deepEqual(
-      ctx.uiState.editorComponentHistory.map((entry) => entry.kind),
-      ["set", "clear"]
-    );
-  });
+  assert.deepEqual(
+    ctx.uiState.editorComponentHistory.map((entry) => entry.kind),
+    ["set", "clear"]
+  );
 });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,11 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { DEFAULT_SETTINGS, DEFAULT_SHORTCUT_KEY, EXTENSION_COMMAND } from "../src/constants.js";
+import { DEFAULT_SHORTCUT_KEY, EXTENSION_COMMAND } from "../src/constants.js";
 import { createPromptsmithExtension } from "../src/index.js";
-import { createCommandContext, createMockPi } from "./helpers.js";
+import { createCommandContext, createMockPi, withPersistedSettings } from "./helpers.js";
 
 void test("extension registers the promptsmith command and shortcut", () => {
   const harness = createMockPi();
@@ -18,27 +15,7 @@ void test("extension registers the promptsmith command and shortcut", () => {
 });
 
 void test("default shortcut does not ignore disabled custom shortcut settings", async () => {
-  const originalHome = process.env.HOME;
-  const tempHome = mkdtempSync(join(tmpdir(), "promptsmith-home-"));
-  process.env.HOME = tempHome;
-
-  try {
-    const settingsPath = join(tempHome, ".pi", "agent", "promptsmith-settings.json");
-    mkdirSync(join(tempHome, ".pi", "agent"), { recursive: true });
-    writeFileSync(
-      settingsPath,
-      `${JSON.stringify(
-        {
-          ...DEFAULT_SETTINGS,
-          shortcutKey: "ctrl+alt+p",
-          shortcutEnabled: false,
-        },
-        null,
-        2
-      )}\n`,
-      "utf8"
-    );
-
+  await withPersistedSettings({ shortcutKey: "ctrl+alt+p", shortcutEnabled: false }, async () => {
     const harness = createMockPi();
     createPromptsmithExtension(harness.pi);
 
@@ -53,36 +30,11 @@ void test("default shortcut does not ignore disabled custom shortcut settings", 
     const messages = ctx.uiState.notifications.map((entry) => entry.message).join("\n");
     assert.match(messages, /shortcut is disabled globally/i);
     assert.doesNotMatch(messages, /shortcut is now ctrl\+alt\+p/i);
-  } finally {
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
-  }
+  });
 });
 
 void test("custom editor is not reinstalled when the shortcut setting is unchanged", async () => {
-  const originalHome = process.env.HOME;
-  const tempHome = mkdtempSync(join(tmpdir(), "promptsmith-home-"));
-  process.env.HOME = tempHome;
-
-  try {
-    const settingsPath = join(tempHome, ".pi", "agent", "promptsmith-settings.json");
-    mkdirSync(join(tempHome, ".pi", "agent"), { recursive: true });
-    writeFileSync(
-      settingsPath,
-      `${JSON.stringify(
-        {
-          ...DEFAULT_SETTINGS,
-          shortcutKey: "ctrl+alt+p",
-        },
-        null,
-        2
-      )}\n`,
-      "utf8"
-    );
-
+  await withPersistedSettings({ shortcutKey: "ctrl+alt+p" }, async () => {
     const harness = createMockPi();
     createPromptsmithExtension(harness.pi);
 
@@ -94,37 +46,13 @@ void test("custom editor is not reinstalled when the shortcut setting is unchang
       await handler({}, ctx);
     }
 
-    assert.deepEqual(ctx.uiState.editorComponentHistory, ["set"]);
-  } finally {
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
-  }
+    assert.equal(ctx.uiState.editorComponentHistory.length, 1);
+    assert.equal(ctx.uiState.editorComponentHistory[0]?.kind, "set");
+  });
 });
 
 void test("session shutdown restores an existing custom editor component", async () => {
-  const originalHome = process.env.HOME;
-  const tempHome = mkdtempSync(join(tmpdir(), "promptsmith-home-"));
-  process.env.HOME = tempHome;
-
-  try {
-    const settingsPath = join(tempHome, ".pi", "agent", "promptsmith-settings.json");
-    mkdirSync(join(tempHome, ".pi", "agent"), { recursive: true });
-    writeFileSync(
-      settingsPath,
-      `${JSON.stringify(
-        {
-          ...DEFAULT_SETTINGS,
-          shortcutKey: "ctrl+alt+p",
-        },
-        null,
-        2
-      )}\n`,
-      "utf8"
-    );
-
+  await withPersistedSettings({ shortcutKey: "ctrl+alt+p" }, async () => {
     const existingFactory = () => ({
       render: () => [],
       invalidate: () => undefined,
@@ -148,38 +76,18 @@ void test("session shutdown restores an existing custom editor component", async
       await handler({}, ctx);
     }
 
+    const history = ctx.uiState.editorComponentHistory;
     assert.equal(ctx.ui.getEditorComponent(), existingFactory);
-    assert.deepEqual(ctx.uiState.editorComponentHistory, ["set", "set"]);
-  } finally {
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
-  }
+    assert.equal(history.length, 2);
+    assert.equal(history[0]?.kind, "set");
+    assert.equal(history[1]?.kind, "set");
+    assert.notEqual(history[0]?.kind === "set" ? history[0].factory : undefined, existingFactory);
+    assert.equal(history[1]?.kind === "set" ? history[1].factory : undefined, existingFactory);
+  });
 });
 
 void test("session shutdown clears the custom editor component", async () => {
-  const originalHome = process.env.HOME;
-  const tempHome = mkdtempSync(join(tmpdir(), "promptsmith-home-"));
-  process.env.HOME = tempHome;
-
-  try {
-    const settingsPath = join(tempHome, ".pi", "agent", "promptsmith-settings.json");
-    mkdirSync(join(tempHome, ".pi", "agent"), { recursive: true });
-    writeFileSync(
-      settingsPath,
-      `${JSON.stringify(
-        {
-          ...DEFAULT_SETTINGS,
-          shortcutKey: "ctrl+alt+p",
-        },
-        null,
-        2
-      )}\n`,
-      "utf8"
-    );
-
+  await withPersistedSettings({ shortcutKey: "ctrl+alt+p" }, async () => {
     const harness = createMockPi();
     createPromptsmithExtension(harness.pi);
 
@@ -191,12 +99,9 @@ void test("session shutdown clears the custom editor component", async () => {
       await handler({}, ctx);
     }
 
-    assert.deepEqual(ctx.uiState.editorComponentHistory, ["set", "clear"]);
-  } finally {
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
-  }
+    assert.deepEqual(
+      ctx.uiState.editorComponentHistory.map((entry) => entry.kind),
+      ["set", "clear"]
+    );
+  });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai";
@@ -187,32 +187,12 @@ export function createRuntimeState(): PromptsmithRuntimeState {
   );
 }
 
-export async function withPersistedSettings(
-  overrides: Partial<PromptsmithSettings>,
-  callback: (tempHome: string) => Promise<void> | void
-): Promise<void> {
-  const originalHome = process.env.HOME;
-  const tempHome = mkdtempSync(join(tmpdir(), "promptsmith-home-"));
-  process.env.HOME = tempHome;
-
-  try {
-    const agentDir = join(tempHome, ".pi", "agent");
-    mkdirSync(agentDir, { recursive: true });
-    writeFileSync(
-      join(agentDir, "promptsmith-settings.json"),
-      `${JSON.stringify({ ...DEFAULT_SETTINGS, ...overrides }, null, 2)}\n`,
-      "utf8"
-    );
-
-    await callback(tempHome);
-  } finally {
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
-    rmSync(tempHome, { recursive: true, force: true });
-  }
+export function createPersistedRuntimeState(
+  overrides: Partial<PromptsmithSettings>
+): PromptsmithRuntimeState {
+  const runtime = createRuntimeState();
+  runtime.persistSettings({ ...DEFAULT_SETTINGS, ...overrides });
+  return runtime;
 }
 
 export function createModel(overrides?: Partial<Model<Api>>): Model<Api> {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai";
@@ -9,8 +9,9 @@ import type {
   SessionEntry,
 } from "@earendil-works/pi-coding-agent";
 import { matchesKey } from "@earendil-works/pi-tui";
-import { SENTINEL_CLOSE, SENTINEL_OPEN } from "../src/constants.js";
+import { DEFAULT_SETTINGS, SENTINEL_CLOSE, SENTINEL_OPEN } from "../src/constants.js";
 import { PromptsmithRuntimeState } from "../src/state.js";
+import type { PromptsmithSettings } from "../src/types.js";
 
 export interface MockPiHarness {
   pi: ExtensionAPI;
@@ -22,6 +23,12 @@ export interface MockPiHarness {
     options: { deliverAs?: "steer" | "followUp" } | undefined;
   }[];
 }
+
+type EditorComponentFactory = NonNullable<ReturnType<ExtensionContext["ui"]["getEditorComponent"]>>;
+
+export type EditorComponentHistoryEntry =
+  | { kind: "set"; factory: EditorComponentFactory }
+  | { kind: "clear" };
 
 export interface MockUiState {
   notifications: { message: string; type: "info" | "warning" | "error" | undefined }[];
@@ -36,7 +43,7 @@ export interface MockUiState {
   customOptionsHistory: string[][];
   customRenderHistory: string[][];
   customInputSequence: string[];
-  editorComponentHistory: ("set" | "clear")[];
+  editorComponentHistory: EditorComponentHistoryEntry[];
   themeCount: number;
 }
 
@@ -180,6 +187,34 @@ export function createRuntimeState(): PromptsmithRuntimeState {
   );
 }
 
+export async function withPersistedSettings(
+  overrides: Partial<PromptsmithSettings>,
+  callback: (tempHome: string) => Promise<void> | void
+): Promise<void> {
+  const originalHome = process.env.HOME;
+  const tempHome = mkdtempSync(join(tmpdir(), "promptsmith-home-"));
+  process.env.HOME = tempHome;
+
+  try {
+    const agentDir = join(tempHome, ".pi", "agent");
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      join(agentDir, "promptsmith-settings.json"),
+      `${JSON.stringify({ ...DEFAULT_SETTINGS, ...overrides }, null, 2)}\n`,
+      "utf8"
+    );
+
+    await callback(tempHome);
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    rmSync(tempHome, { recursive: true, force: true });
+  }
+}
+
 export function createModel(overrides?: Partial<Model<Api>>): Model<Api> {
   return {
     id: "gpt-5",
@@ -211,7 +246,7 @@ export function createCommandContext(options?: {
   apiKeys?: Map<string, string | undefined>;
   requestHeaders?: Map<string, Record<string, string> | undefined>;
   cwd?: string;
-  editorComponentFactory?: ReturnType<ExtensionContext["ui"]["getEditorComponent"]>;
+  editorComponentFactory?: EditorComponentFactory;
 }): ExtensionCommandContext & { uiState: MockUiState } {
   const uiState: MockUiState = {
     notifications: [],
@@ -409,7 +444,7 @@ export function createCommandContext(options?: {
       },
       setEditorComponent: (factory: typeof editorComponentFactory) => {
         editorComponentFactory = factory;
-        uiState.editorComponentHistory.push(factory ? "set" : "clear");
+        uiState.editorComponentHistory.push(factory ? { kind: "set", factory } : { kind: "clear" });
       },
       getEditorComponent: () => editorComponentFactory,
       theme: {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -211,6 +211,7 @@ export function createCommandContext(options?: {
   apiKeys?: Map<string, string | undefined>;
   requestHeaders?: Map<string, Record<string, string> | undefined>;
   cwd?: string;
+  editorComponentFactory?: ReturnType<ExtensionContext["ui"]["getEditorComponent"]>;
 }): ExtensionCommandContext & { uiState: MockUiState } {
   const uiState: MockUiState = {
     notifications: [],
@@ -230,6 +231,7 @@ export function createCommandContext(options?: {
   };
 
   const allModels = options?.allModels ?? [options?.model ?? createModel()];
+  let editorComponentFactory = options?.editorComponentFactory;
   const apiKeys =
     options?.apiKeys ?? new Map(allModels.map((model) => [modelKey(model), "test-key"]));
   const requestHeaders = options?.requestHeaders ?? new Map<string, Record<string, string>>();
@@ -405,9 +407,11 @@ export function createCommandContext(options?: {
       pasteToEditor: (text: string) => {
         uiState.editorText = text;
       },
-      setEditorComponent: (factory: unknown) => {
+      setEditorComponent: (factory: typeof editorComponentFactory) => {
+        editorComponentFactory = factory;
         uiState.editorComponentHistory.push(factory ? "set" : "clear");
       },
+      getEditorComponent: () => editorComponentFactory,
       theme: {
         fg: (_color: string, text: string) => text,
         bg: (_color: string, text: string) => text,

--- a/test/intent-and-strategy.test.ts
+++ b/test/intent-and-strategy.test.ts
@@ -157,6 +157,28 @@ void test("buildPromptContext caps the safe input budget to the enhancer model u
   );
 });
 
+void test("gpt strategy request includes OpenAI prompt guidance", () => {
+  const request = buildGptStrategyRequest(
+    createPromptContext({ effectiveRewriteMode: "execution-contract", intent: "research" })
+  );
+  const text = `${request.systemPrompt}\n${extractUserText(request)}`;
+
+  assert.match(text, /OpenAI prompt guidance/i);
+  assert.match(text, /outcome-first/i);
+  assert.match(text, /retrieval budget/i);
+  assert.match(text, /stop rules/i);
+});
+
+void test("claude strategy request does not include OpenAI-specific guidance", () => {
+  const request = buildClaudeStrategyRequest(
+    createPromptContext({ effectiveRewriteMode: "execution-contract", intent: "research" })
+  );
+  const text = `${request.systemPrompt}\n${extractUserText(request)}`;
+
+  assert.doesNotMatch(text, /OpenAI prompt guidance/i);
+  assert.doesNotMatch(text, /retrieval budget/i);
+});
+
 void test("gpt strategy request changes instructions between plain and execution-contract modes", () => {
   const plainRequest = buildGptStrategyRequest(
     createPromptContext({ effectiveRewriteMode: "plain", intent: "explain" })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPT-specific guidance for prompt rewrites and requests for concise enhancer output when supported.

* **Bug Fixes**
  * Preserve and restore existing custom editor components when installing/removing the Promptsmith shortcut.

* **Documentation**
  * Updated "How it works" and "Safety guarantees" with GPT behavior and concise-output guarantees.

* **Tests**
  * Added tests for enhancer request options, strategy prompt differences, editor-component restore and shortcut behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ayagmar/pi-promptsmith/pull/8)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->