### PR TITLE
fix(promptsmith): harden enhancer provider responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ There are two ways to see status:
 - timeout
 - current draft intent and effective rewrite mode, when the editor is readable
 - the last enhancement outcome, enhancer model, and whether a format-retry was needed
-- the last enhancement failure detail when a model breaks the sentinel contract
+- the last enhancement failure detail for sentinel-contract or provider/API stop errors
 
 Outside interactive editor mode, draft-aware status degrades gracefully.
 
@@ -294,6 +294,7 @@ Promptsmith keeps a few important guarantees:
 - only one enhancement runs at a time
 - output must contain exactly one sentinel block
 - invalid model-output failures say whether the model missed the sentinel, emitted multiple blocks, added extra text, or returned an empty block
+- provider/API stop errors are reported directly instead of being masked as empty sentinel failures
 - GPT enhancer calls request concise text output where the Pi/OpenAI provider supports verbosity controls
 - a bad first model response is retried once with a stricter format reminder before Promptsmith fails closed
 - single collapsed Pi paste markers can be recovered from the clipboard; multi-marker drafts fail closed

--- a/src/enhance.ts
+++ b/src/enhance.ts
@@ -272,10 +272,8 @@ async function generateEnhancedPrompt(
       return null;
     }
 
-    const primaryText = extractTextResponse(primaryResponse);
-
     try {
-      return parseEnhancedPrompt(primaryText);
+      return parseEnhancedAssistantResponse(primaryResponse);
     } catch (error) {
       if (!isInvalidModelOutputError(error)) {
         throw error;
@@ -296,10 +294,8 @@ async function generateEnhancedPrompt(
         return null;
       }
 
-      const retryText = extractTextResponse(retryResponse);
-
       try {
-        const parsed = parseEnhancedPrompt(retryText);
+        const parsed = parseEnhancedAssistantResponse(retryResponse);
         tracker.recoveredAfterRetry = true;
         return parsed;
       } catch (retryError) {
@@ -312,9 +308,9 @@ async function generateEnhancedPrompt(
           buildInvalidModelOutputFailureMessage(
             preparation.enhancerModel.label,
             error,
-            primaryText,
+            primaryResponse,
             retryError,
-            retryText
+            retryResponse
           )
         );
       }
@@ -365,6 +361,14 @@ async function runCompletion(
     return null;
   }
 
+  if (response.stopReason === "error") {
+    throw createCompletionStopReasonError(preparation.enhancerModel.label, response);
+  }
+
+  if (response.stopReason === "toolUse") {
+    throw createCompletionStopReasonError(preparation.enhancerModel.label, response);
+  }
+
   return response;
 }
 
@@ -378,6 +382,7 @@ function buildCompletionOptions(
     ...(typeof apiKey === "string" ? { apiKey } : {}),
     ...(headers ? { headers } : {}),
     ...buildGptCompletionOptions(preparation.enhancerModel.model),
+    ...buildProviderCompatibilityOptions(preparation.enhancerModel.model),
     signal: requestSignal,
     maxTokens: Math.min(preparation.enhancerModel.model.maxTokens, ENHANCER_MAX_OUTPUT_TOKENS),
   };
@@ -400,6 +405,62 @@ function isGptModel(model: Model<Api>): boolean {
     id.startsWith("gpt") ||
     /^o[1-9]/.test(id)
   );
+}
+
+function buildProviderCompatibilityOptions(model: Model<Api>): CompleteOptions {
+  if (isOpenRouterMiniMaxModel(model)) {
+    return { onPayload: normalizeOpenRouterMiniMaxPayload };
+  }
+
+  return {};
+}
+
+function isOpenRouterMiniMaxModel(model: Model<Api>): boolean {
+  return (
+    model.provider.toLowerCase() === "openrouter" && model.id.toLowerCase().startsWith("minimax/")
+  );
+}
+
+function normalizeOpenRouterMiniMaxPayload(payload: unknown): unknown {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  let changed = false;
+  const next: Record<string, unknown> = { ...payload };
+
+  if (Array.isArray(next.messages)) {
+    const rawMessages: unknown[] = next.messages;
+    const messages = rawMessages.map((message) => {
+      if (!isRecord(message) || message.role !== "developer") {
+        return message;
+      }
+
+      changed = true;
+      return { ...message, role: "system" };
+    });
+
+    if (changed) {
+      next.messages = messages;
+    }
+  }
+
+  if (next.max_completion_tokens !== undefined && next.max_tokens === undefined) {
+    next.max_tokens = next.max_completion_tokens;
+    delete next.max_completion_tokens;
+    changed = true;
+  }
+
+  if (next.store === false) {
+    delete next.store;
+    changed = true;
+  }
+
+  return changed ? next : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function buildRetryRequest(request: Context): Context {
@@ -490,6 +551,27 @@ function sendEnhancedPromptIfConfigured(
   }
 }
 
+function createCompletionStopReasonError(
+  enhancerModelLabel: string,
+  response: AssistantMessage
+): Error {
+  if (response.stopReason === "error") {
+    const providerError = response.errorMessage?.trim();
+    return new Error(
+      [
+        `Promptsmith enhancer model ${enhancerModelLabel} request failed before returning an enhanced prompt.`,
+        providerError ? `Provider error: ${providerError}` : "Provider error: no details returned.",
+        `Response preview: ${formatAssistantResponsePreview(response)}`,
+        "Try /promptsmith status to inspect the current enhancer configuration or switch enhancer models.",
+      ].join("\n")
+    );
+  }
+
+  return new Error(
+    `Promptsmith enhancer model ${enhancerModelLabel} stopped with ${response.stopReason} before returning an enhanced prompt.`
+  );
+}
+
 function buildInvalidModelOutputFailureSummary(
   primaryError: PromptsmithInvalidModelOutputError,
   retryError: PromptsmithInvalidModelOutputError
@@ -500,19 +582,33 @@ function buildInvalidModelOutputFailureSummary(
 function buildInvalidModelOutputFailureMessage(
   enhancerModelLabel: string,
   primaryError: PromptsmithInvalidModelOutputError,
-  primaryText: string,
+  primaryResponse: AssistantMessage,
   retryError: PromptsmithInvalidModelOutputError,
-  retryText: string
+  retryResponse: AssistantMessage
 ): string {
   return [
     `Promptsmith enhancer model ${enhancerModelLabel} returned invalid output twice.`,
     `Primary failure: ${describeInvalidModelOutputReason(primaryError.reason)}.`,
     `Retry failure: ${describeInvalidModelOutputReason(retryError.reason)}.`,
     `Expected exactly one sentinel block: ${buildSentinelReminder()}`,
-    `Primary response preview: ${formatModelOutputPreview(primaryText)}`,
-    `Retry response preview: ${formatModelOutputPreview(retryText)}`,
+    `Primary response preview: ${formatAssistantResponsePreview(primaryResponse)}`,
+    `Retry response preview: ${formatAssistantResponsePreview(retryResponse)}`,
     "Try /promptsmith status to inspect the current enhancer configuration or switch to a more format-reliable enhancer model.",
   ].join("\n");
+}
+
+function formatAssistantResponsePreview(response: AssistantMessage): string {
+  const text = extractTextResponse(response);
+  if (text) {
+    return formatModelOutputPreview(text);
+  }
+
+  const thinkingText = extractThinkingResponse(response);
+  if (thinkingText) {
+    return formatEmptyResponsePreview(response, "received thinking-only content");
+  }
+
+  return formatEmptyResponsePreview(response);
 }
 
 function formatModelOutputPreview(text: string, maxLength = 220): string {
@@ -524,6 +620,17 @@ function formatModelOutputPreview(text: string, maxLength = 220): string {
   return normalized.length <= maxLength ? normalized : `${normalized.slice(0, maxLength - 1)}…`;
 }
 
+function formatEmptyResponsePreview(response: AssistantMessage, note?: string): string {
+  const details = [
+    response.stopReason !== "stop" ? `stop reason: ${response.stopReason}` : "",
+    note,
+  ]
+    .filter(Boolean)
+    .join("; ");
+
+  return details ? `<empty response; ${details}>` : "<empty response>";
+}
+
 async function previewEnhancedPrompt(
   ctx: ExtensionContext,
   enhancedPrompt: string
@@ -531,10 +638,48 @@ async function previewEnhancedPrompt(
   return ctx.ui.editor("Review enhanced prompt", enhancedPrompt);
 }
 
+function parseEnhancedAssistantResponse(response: AssistantMessage): string {
+  const text = extractTextResponse(response);
+
+  try {
+    return parseEnhancedPrompt(text);
+  } catch (error) {
+    if (!shouldTryThinkingFallback(error, text)) {
+      throw error;
+    }
+
+    const thinkingText = extractThinkingResponse(response);
+    if (!thinkingText) {
+      throw error;
+    }
+
+    try {
+      return parseEnhancedPrompt(thinkingText);
+    } catch {
+      throw error;
+    }
+  }
+}
+
+function shouldTryThinkingFallback(error: unknown, text: string): boolean {
+  return !text && isInvalidModelOutputError(error) && error.reason === "missing-sentinel-block";
+}
+
 function extractTextResponse(response: AssistantMessage): string {
   return response.content
     .filter((part): part is { type: "text"; text: string } => part.type === "text")
     .map((part) => part.text)
+    .join("\n")
+    .trim();
+}
+
+function extractThinkingResponse(response: AssistantMessage): string {
+  return response.content
+    .filter(
+      (part): part is { type: "thinking"; thinking: string; redacted?: boolean } =>
+        part.type === "thinking" && part.redacted !== true
+    )
+    .map((part) => part.thinking)
     .join("\n")
     .trim();
 }

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -143,6 +143,55 @@ void test("promptsmith command does not add GPT-only request options to Claude e
   assert.equal(requestOptions?.textVerbosity, undefined);
 });
 
+void test("promptsmith command normalizes OpenRouter MiniMax enhancer payloads", async () => {
+  const runtime = createRuntimeState();
+  const harness = createMockPi();
+  const model = createModel({
+    provider: "openrouter",
+    id: "minimax/minimax-m2.5",
+    api: "openai-completions",
+    baseUrl: "https://openrouter.ai/api/v1",
+  });
+  const ctx = createCommandContext({ model, allModels: [model], editorText: "fix this prompt" });
+  let requestOptions: Record<string, unknown> | undefined;
+
+  await handlePromptsmithCommand(
+    "",
+    ctx,
+    runtime,
+    createServices(harness, (_model, _context, options) => {
+      requestOptions = options;
+      return Promise.resolve(createCompleteResponse("Enhanced prompt"));
+    })
+  );
+
+  const onPayload = requestOptions?.onPayload;
+  assert.equal(typeof onPayload, "function");
+
+  const normalized = await (onPayload as (payload: unknown) => unknown)({
+    model: "minimax/minimax-m2.5",
+    messages: [
+      { role: "developer", content: "system instructions" },
+      { role: "user", content: "draft" },
+    ],
+    stream: true,
+    store: false,
+    max_completion_tokens: 1200,
+    reasoning: { effort: "none" },
+  });
+
+  assert.deepEqual(normalized, {
+    model: "minimax/minimax-m2.5",
+    messages: [
+      { role: "system", content: "system instructions" },
+      { role: "user", content: "draft" },
+    ],
+    stream: true,
+    max_tokens: 1200,
+    reasoning: { effort: "none" },
+  });
+});
+
 void test("empty editor opens settings instead of failing", async () => {
   const runtime = createRuntimeState();
   const harness = createMockPi();
@@ -507,6 +556,62 @@ void test("invalid model output errors include model-specific diagnostics", asyn
   assert.match(message, /primary response preview: sure — here is the rewrite/i);
   assert.match(message, /retry response preview:/i);
   assert.match(message, /try \/promptsmith status/i);
+});
+
+void test("thinking-only sentinel responses can still enhance the draft", async () => {
+  const runtime = createRuntimeState();
+  const harness = createMockPi();
+  const ctx = createCommandContext({ model: createModel(), editorText: "original draft" });
+
+  await handlePromptsmithCommand(
+    "",
+    ctx,
+    runtime,
+    createServices(harness, () =>
+      Promise.resolve({
+        ...createAssistantResponse(""),
+        content: [
+          {
+            type: "thinking" as const,
+            thinking:
+              "<promptsmith-enhanced-prompt>Recovered from thinking-only content</promptsmith-enhanced-prompt>",
+          },
+        ],
+      })
+    )
+  );
+
+  assert.equal(ctx.uiState.editorText, "Recovered from thinking-only content");
+  assert.match(ctx.uiState.notifications.at(-1)?.message ?? "", /enhanced the current draft/i);
+});
+
+void test("provider stop errors are reported instead of sentinel failures", async () => {
+  const runtime = createRuntimeState();
+  const harness = createMockPi();
+  const ctx = createCommandContext({ model: createModel(), editorText: "original draft" });
+  let callCount = 0;
+
+  await handlePromptsmithCommand(
+    "",
+    ctx,
+    runtime,
+    createServices(harness, () => {
+      callCount += 1;
+      return Promise.resolve({
+        ...createAssistantResponse(""),
+        content: [],
+        stopReason: "error" as const,
+        errorMessage: "OpenRouter error: model is unavailable",
+      });
+    })
+  );
+
+  const message = ctx.uiState.notifications.at(-1)?.message ?? "";
+  assert.equal(callCount, 1);
+  assert.equal(ctx.uiState.editorText, "original draft");
+  assert.match(message, /request failed before returning an enhanced prompt/i);
+  assert.match(message, /openrouter error: model is unavailable/i);
+  assert.doesNotMatch(message, /missing sentinel block/i);
 });
 
 void test("hung enhancement times out and leaves the editor unchanged", async () => {


### PR DESCRIPTION
## Summary
- report provider/API stop errors directly instead of sentinel failures
- normalize OpenRouter MiniMax enhancer payloads for compatibility
- recover exact sentinel blocks from thinking-only responses

## Tests
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated error reporting documentation to describe enhanced failure scenarios, including provider/API stop errors now reported directly instead of being masked.

* **Bug Fixes**
  * Improved error handling for additional completion stop conditions.
  * Enhanced output parsing with fallback support when standard sentinel blocks are unavailable.
  * Better error messages with improved assistant response previews.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ayagmar/pi-promptsmith/pull/9)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->